### PR TITLE
Force game to use HTML5 Canvas renderer

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -29,7 +29,7 @@ var game = {
     // Run on page load.
     "onload" : function () {
         // Initialize the video.
-        if (!me.video.init(TILE_WIDTH*TILE_COUNT_WIDTH, TILE_HEIGHT*TILE_COUNT_HEIGHT, {wrapper : "screen", scale : "auto", scaleMethod : "fit"})) {
+        if (!me.video.init(TILE_WIDTH*TILE_COUNT_WIDTH, TILE_HEIGHT*TILE_COUNT_HEIGHT, {wrapper : "screen", renderer : me.video.CANVAS, scale : "auto", scaleMethod : "fit"})) {
             alert("Your browser does not support HTML5 canvas.");
             return;
         }

--- a/js/screens/gameEnd.js
+++ b/js/screens/gameEnd.js
@@ -40,7 +40,7 @@ game.GameEndScreen = me.Stage.extend({
 				me.game.viewport.height / gameOverImage.height);
 			me.game.world.addChild(gameOverImage, screenNum);
         }
-		// Return to the game title screen after finishing the game over screens.
+		// Return to the game title screen after finishing the game end screens.
         else if (action === "space") {
 			game.data.life = START_LIFE;
 			game.data.wave = 0;


### PR DESCRIPTION
Force game to use HTML5 Canvas renderer instead of dynamically choosing a renderer for a user depending on the user's computer hardware capability.

This is a workaround for the bug documented here:
https://docs.google.com/document/d/1g9MJbXkfVyOXihk4ZBVynJzd82TNaCuR95vczqNXHa0/edit?usp=sharing

Related melonJS documentation is here:
http://melonjs.github.io/melonJS/docs/me.video.html