### PR TITLE
Update game over and game end screens to play and stop music using pl…

### DIFF
--- a/js/screens/gameEnd.js
+++ b/js/screens/gameEnd.js
@@ -23,7 +23,7 @@ game.GameEndScreen = me.Stage.extend({
 	me.game.world.addChild(gameEndImage, screenNum);
 
 	// Play a looping music track.
-	me.audio.playTrack("tgfcoder-FrozenJam-SeamlessLoop");
+	me.audio.play("tgfcoder-FrozenJam-SeamlessLoop", true);
 
 	// Bind necessary keys to navigate screens
     me.input.bindKey(me.input.KEY.SPACE, "space", true);
@@ -46,7 +46,7 @@ game.GameEndScreen = me.Stage.extend({
 		// Return to the game title screen after finishing the game end screens.
         else if (action === "space") {
 			// Stop the music.
-			me.audio.stopTrack();
+			me.audio.stop("tgfcoder-FrozenJam-SeamlessLoop");
 			
 			game.data.life = START_LIFE;
 			game.data.wave = 0;

--- a/js/screens/gameOver.js
+++ b/js/screens/gameOver.js
@@ -23,7 +23,7 @@ game.GameOverScreen = me.Stage.extend({
 	me.game.world.addChild(gameOverImage, screenNum);
 
 	// Play a looping music track.
-	me.audio.playTrack("Iwan Gabovitch - Dark Ambience Loop");
+	me.audio.play("Iwan Gabovitch - Dark Ambience Loop", true);
 
 	// Bind necessary keys to navigate screens
     me.input.bindKey(me.input.KEY.SPACE, "space", true);
@@ -59,7 +59,7 @@ game.GameOverScreen = me.Stage.extend({
         else if ((action === "space" && game.data.level == 0) ||
 			(action === "enter" && screenNum == lastScreen)) {
             // Stop the music.
-			me.audio.stopTrack();
+			me.audio.stop("Iwan Gabovitch - Dark Ambience Loop");
 			
 			game.data.life = START_LIFE;
 			game.data.wave = 0;
@@ -70,7 +70,7 @@ game.GameOverScreen = me.Stage.extend({
 		// Return to the play screen at the level after level01 where the player lost, if they want.
         else if (action === "backspace" && game.data.level > 0) {
             // Stop the music.
-			me.audio.stopTrack();
+			me.audio.stop("Iwan Gabovitch - Dark Ambience Loop");
 			
 			game.data.life = game.data.lastStartingLife;
 			game.data.wave = 0;


### PR DESCRIPTION
…ay() with loop option set and stop()

Update game over and game end screens to play and stop looping music using play() with loop option set and stop() instead of the playTrack() and stopTrack() functions, the latter of which do not work consistently on the live site.

This change works locally (the music loops at those screens as expected) on Ricardo's computer, however it is not known if this change will ensure music looping works at those screens as expected on the live site and testing is needed to check that.